### PR TITLE
Add custom route_registrar health_check script

### DIFF
--- a/jobs/uaa-customized/spec
+++ b/jobs/uaa-customized/spec
@@ -6,6 +6,7 @@ packages:
 templates:
   pre-start: bin/pre-start
   post-start: bin/post-start
+  bin/health_check: bin/health_check
 
   resources/oss/stylesheets/application.css: resources/oss/stylesheets/application.css
   resources/oss/images/product-logo.png: resources/oss/images/product-logo.png

--- a/jobs/uaa-customized/spec
+++ b/jobs/uaa-customized/spec
@@ -11,20 +11,4 @@ templates:
   resources/oss/images/product-logo.png: resources/oss/images/product-logo.png
   resources/oss/images/square-logo.png: resources/oss/images/square-logo.png
 
-properties:
-  # Copied from https://github.com/cloudfoundry/uaa-release/blob/develop/jobs/uaa/spec
-  uaa.password.policy.minLength:
-    description: "Minimum number of characters required for password to be considered valid"
-    default: 0
-  uaa.password.policy.requireUpperCaseCharacter:
-    description: "Minimum number of uppercase characters required for password to be considered valid"
-    default: 0
-  uaa.password.policy.requireLowerCaseCharacter:
-    description: "Minimum number of lowercase characters required for password to be considered valid"
-    default: 0
-  uaa.password.policy.requireDigit:
-    description: "Minimum number of digits required for password to be considered valid"
-    default: 0
-  uaa.password.policy.requireSpecialCharacter:
-    description: "Minimum number of special characters required for password to be considered valid"
-    default: 0
+properties: {}

--- a/jobs/uaa-customized/templates/bin/health_check
+++ b/jobs/uaa-customized/templates/bin/health_check
@@ -15,7 +15,7 @@ if [ "$( < "$status_file" )" != "up" ]; then
 fi
 
 uaa_url="https://127.0.0.1:8443/healthz"
-resp="$(curl -ksS -m 5 --connect-timeout 2 "$uaa_url")"
+resp="$(curl --fail --insecure --silent --show-error --max-time 5 --connect-timeout 2 "$uaa_url")"
 
 if [ "$resp" = "ok" ]; then
   exit 0

--- a/jobs/uaa-customized/templates/bin/health_check
+++ b/jobs/uaa-customized/templates/bin/health_check
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eu
+
+status_file='/var/vcap/jobs/uaa-customized/status'
+
+# If status file does not exist then not yet ready to serve
+if ! [ -e "$status_file" ]; then
+  exit 1
+fi
+
+# If contents of status file is not 'up' then not yet ready to serve
+if [ "$( < "$status_file" )" != "up" ]; then
+  exit 1
+fi
+
+uaa_url="https://127.0.0.1:8443/healthz"
+resp="$(curl -ksS -m 5 --connect-timeout 2 "$uaa_url")"
+
+if [ "$resp" = "ok" ]; then
+  exit 0
+fi
+
+exit 1

--- a/jobs/uaa-customized/templates/post-start
+++ b/jobs/uaa-customized/templates/post-start
@@ -1,5 +1,70 @@
 #!/bin/bash
-set -e
+set -eu
+
+wait_down() {
+  for _ in {1..120}; do
+    echo 'checking if uaa is down'
+    if ! curl -sfk https://localhost:8443; then
+      echo 'uaa is down'
+      return 0
+    fi
+    echo 'uaa is up...sleeping'
+    sleep 5
+  done
+  echo 'timed out waiting for uaa to be down'
+  return 1
+}
+
+wait_up() {
+  for _ in {1..120}; do
+    echo 'checking if uaa is up'
+    if curl -sfk https://localhost:8443; then
+      echo 'uaa is up'
+      return 0
+    fi
+    echo 'uaa is not up...sleeping'
+    sleep 5
+  done
+  echo 'timed out waiting for uaa to be up'
+  return 1
+}
+
+##########. WARNING. #################
+## This is a hack. plain and simple.
+## Do not try this at home.
+######################################
+
+wait_up
+
+PACKAGES_DIR=/var/vcap/packages
+JOB_DIR=/var/vcap/jobs/uaa-customized
+
+# Wait until UAA pre-start has finished copying files from packages to avoid
+# race condition between pre-start scripts
+until [ -d /var/vcap/data/uaa/ ]; do
+  sleep 1
+done
+sleep 5
+
+WARFILE="${PACKAGES_DIR}/uaa/tomcat/webapps/ROOT.war"
+JARFILE=$(unzip -v "${WARFILE}" | grep cloudfoundry-identity-server- | awk '{print $8}')
+WAR_TEMPDIR="$(mktemp -d)"
+
+pushd "${WAR_TEMPDIR}"
+  unzip "${WARFILE}" "${JARFILE}"
+
+  # ignore templates for now
+  # mkdir -p templates/web
+  # cp -a "${JOB_DIR}"/web/* templates/web
+  # zip -r "${JARFILE}" templates/web
+  # zip "$WARFILE" "$JARFILE"
+
+  mkdir -p resources
+  cp -a "${JOB_DIR}"/resources/* resources/
+  zip -r "${WARFILE}" resources
+popd
+
+rm -rf "${WAR_TEMPDIR}"
 
 # Recopy artifacts from /var/vcap/packages/uaa to /var/vcap/data/uaa
 /var/vcap/jobs/uaa/bin/pre-start
@@ -7,25 +72,26 @@ set -e
 # Restart uaa to apply template overrides
 /var/vcap/bosh/bin/monit restart uaa
 
-wait_down() {
-  for _ in {1..120}; do
-    if ! curl -fk https://localhost:8443; then
-      return 0
-    fi
-    sleep 5
-  done
-  return 1
-}
-
-wait_up() {
-  for _ in {1..120}; do
-    if curl -fk https://localhost:8443; then
-      return 0
-    fi
-    sleep 5
-  done
-  return 1
-}
-
 wait_down
 wait_up
+
+echo 'up' > /var/vcap/jobs/uaa-customized/status
+
+for _ in {1..30}; do
+  echo 'running route_registrar health_check script'
+
+  # specifically run the customized script otherwise
+  # bosh will think uaa is registered when it is not
+  if /var/vcap/jobs/uaa-customized/bin/health_check; then
+    echo 'route_registrar will register uaa soon'
+    sleep 15 # this is over the registration interval for uaa
+    echo 'done'
+    exit 0
+  fi
+
+  echo 'route_registrar health_check script is not in a good state'
+  sleep 1
+done
+
+echo 'timed out waiting for route_registrar health_check script'
+exit 1

--- a/jobs/uaa-customized/templates/post-start
+++ b/jobs/uaa-customized/templates/post-start
@@ -4,7 +4,7 @@ set -eu
 wait_down() {
   for _ in {1..120}; do
     echo 'checking if uaa is down'
-    if ! curl -sfk https://localhost:8443; then
+    if ! curl --fail --insecure --silent --show-error --max-time 5 --connect-timeout 2 https://localhost:8443/healthz; then
       echo 'uaa is down'
       return 0
     fi
@@ -18,7 +18,7 @@ wait_down() {
 wait_up() {
   for _ in {1..120}; do
     echo 'checking if uaa is up'
-    if curl -sfk https://localhost:8443; then
+    if curl --fail --insecure --silent --show-error --max-time 5 --connect-timeout 2 https://localhost:8443/healthz; then
       echo 'uaa is up'
       return 0
     fi

--- a/jobs/uaa-customized/templates/post-start
+++ b/jobs/uaa-customized/templates/post-start
@@ -1,10 +1,20 @@
 #!/bin/bash
 set -eu
 
+check_uaa() {
+  curl --fail \
+       --insecure \
+       --silent \
+       --show-error \
+       --max-time 5 \
+       --connect-timeout 2 \
+       https://localhost:8443/healthz
+}
+
 wait_down() {
   for _ in {1..120}; do
     echo 'checking if uaa is down'
-    if ! curl --fail --insecure --silent --show-error --max-time 5 --connect-timeout 2 https://localhost:8443/healthz; then
+    if ! check_uaa; then
       echo 'uaa is down'
       return 0
     fi
@@ -18,7 +28,7 @@ wait_down() {
 wait_up() {
   for _ in {1..120}; do
     echo 'checking if uaa is up'
-    if curl --fail --insecure --silent --show-error --max-time 5 --connect-timeout 2 https://localhost:8443/healthz; then
+    if check_uaa; then
       echo 'uaa is up'
       return 0
     fi

--- a/jobs/uaa-customized/templates/pre-start
+++ b/jobs/uaa-customized/templates/pre-start
@@ -1,37 +1,4 @@
 #!/bin/bash
 set -e
 
-##########. WARNING. #################
-## This is a hack. plain and simple.
-## Do not try this at home.
-######################################
-
-PACKAGES_DIR=/var/vcap/packages
-JOB_DIR=/var/vcap/jobs/uaa-customized
-
-# Wait until UAA pre-start has finished copying files from packages to avoid
-# race condition between pre-start scripts
-until [ -d /var/vcap/data/uaa/ ]; do
-  sleep 1
-done
-sleep 5
-
-WARFILE="${PACKAGES_DIR}/uaa/tomcat/webapps/ROOT.war"
-JARFILE=$(unzip -v "${WARFILE}" | grep cloudfoundry-identity-server- | awk '{print $8}')
-WAR_TEMPDIR="$(mktemp -d)"
-
-pushd "${WAR_TEMPDIR}"
-  unzip "${WARFILE}" "${JARFILE}"
-
-  # ignore templates for now
-  # mkdir -p templates/web
-  # cp -a "${JOB_DIR}"/web/* templates/web
-  # zip -r "${JARFILE}" templates/web
-  # zip "$WARFILE" "$JARFILE"
-
-  mkdir -p resources
-  cp -a "${JOB_DIR}"/resources/* resources/
-  zip -r "${WARFILE}" resources
-popd
-
-rm -rf "${WAR_TEMPDIR}"
+echo 'down' > /var/vcap/jobs/uaa-customized/status


### PR DESCRIPTION
What
----

Add a `health_check` script intended to override the `uaa-release` `route_registrar` `health_check` script.

UAA gets registered with `gorouter` by the `route_registrar` job which looks at a `health_check` script. This script checks whether UAA is up `curl -sk https://localhost:8443` basically.

When UAA starts for the first time `route_registrar` sometimes registers it with `gorouter`, we then immediately stop it to do our horrible hacks. The instance will then receive a few requests that it cannot handle.

This PR makes a new `health_check` script which does basically the same thing but it also has a lock file. `pre-start` tells the script to tell `route_registrar` that this instance is not ready. Once `post-start` has hacked around with UAA and that post-fiddling UAA is healthy, then we remove the lock file, and `route_registrar` will tell `gorouter` about the instance.

How to review
-------------

Code review

Run it down a pipeline.

Who can review
--------------

Not @tlwr, probably helpful to pair on it