### PR TITLE
[#166027802] Style Error Pages

### DIFF
--- a/jobs/uaa-customized/spec
+++ b/jobs/uaa-customized/spec
@@ -36,6 +36,7 @@ templates:
   web/forgot_password.html: web/forgot_password.html
   web/external_auth_error.html: web/external_auth_error.html
   web/error.html: web/error.html
+  web/passcode.html: web/passcode.html
 
 properties:
   region:

--- a/jobs/uaa-customized/spec
+++ b/jobs/uaa-customized/spec
@@ -34,6 +34,8 @@ templates:
   web/login.html: web/login.html
   web/invitations/accept_invite.html: web/invitations/accept_invite.html
   web/forgot_password.html: web/forgot_password.html
+  web/external_auth_error.html: web/external_auth_error.html
+  web/error.html: web/error.html
 
 properties:
   region:

--- a/jobs/uaa-customized/templates/web/error.html
+++ b/jobs/uaa-customized/templates/web/error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<head>
+</head>
+<div class="govuk-width-container" layout:fragment="page-content">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+        <p class="govuk-body">
+          <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">Contact GOV.UK PaaS support</a> if you have any issues with the platform.
+        </p>
+      </div>
+    </div>
+  </main>
+</div>
+</html>

--- a/jobs/uaa-customized/templates/web/external_auth_error.html
+++ b/jobs/uaa-customized/templates/web/external_auth_error.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<!--
+  ~ *******************************************************************************
+  ~       Cloud Foundry Copyright (c) [2009-2015] Pivotal Software, Inc. All Rights Reserved.
+  ~
+  ~       This product is licensed to you under the Apache License, Version 2.0 (the "License").
+  ~       You may not use this product except in compliance with the License.
+  ~
+  ~       This product includes a number of subcomponents with
+  ~       separate copyright notices and license terms. Your use of these
+  ~       subcomponents is subject to the terms and conditions of the
+  ~       subcomponent's license, as noted in the LICENSE file.
+  ~ *******************************************************************************
+  -->
+
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<head>
+</head>
+<body>
+<div class="island" layout:fragment="page-content">
+    <div class="island-content">
+        <div th:if="${error_message_code}" class="alert alert-error">
+            <p th:text="#{${error_message_code}}">Error Message</p>
+        </div>
+    </div>
+    <h2 th:text="${saml_error}">
+    </h2>
+    <h2 th:if="${param.error}" th:text="${param.error[0]}">Error Message
+    </h2>
+</div>
+</body>
+</html>

--- a/jobs/uaa-customized/templates/web/external_auth_error.html
+++ b/jobs/uaa-customized/templates/web/external_auth_error.html
@@ -1,32 +1,23 @@
 <!DOCTYPE html>
-<!--
-  ~ *******************************************************************************
-  ~       Cloud Foundry Copyright (c) [2009-2015] Pivotal Software, Inc. All Rights Reserved.
-  ~
-  ~       This product is licensed to you under the Apache License, Version 2.0 (the "License").
-  ~       You may not use this product except in compliance with the License.
-  ~
-  ~       This product includes a number of subcomponents with
-  ~       separate copyright notices and license terms. Your use of these
-  ~       subcomponents is subject to the terms and conditions of the
-  ~       subcomponent's license, as noted in the LICENSE file.
-  ~ *******************************************************************************
-  -->
-
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
 <head>
 </head>
 <body>
-<div class="island" layout:fragment="page-content">
-    <div class="island-content">
-        <div th:if="${error_message_code}" class="alert alert-error">
-            <p th:text="#{${error_message_code}}">Error Message</p>
-        </div>
+<div class="govuk-grid-row" layout:fragment="page-content">
+  <div class="govuk-grid-column-two-thirds">
+    <div th:if="${param.error}" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+          There was an error when authenticating against the external identity provider. You may need to:
+      </h2>
+      <div class="govuk-error-summary__body" th:if="${#strings.indexOf(param.error[0], 'The user account must be pre-created')}">
+        <ul class="govuk-list govuk-error-summary__list">
+          <li>Sign in with your email address and password</li>
+          <li>Switch region</li>
+          <li>Request an account</li>
+        </ul>
+      </div>
     </div>
-    <h2 th:text="${saml_error}">
-    </h2>
-    <h2 th:if="${param.error}" th:text="${param.error[0]}">Error Message
-    </h2>
+  </div>
 </div>
 </body>
 </html>

--- a/jobs/uaa-customized/templates/web/external_auth_error.html
+++ b/jobs/uaa-customized/templates/web/external_auth_error.html
@@ -5,17 +5,38 @@
 <body>
 <div class="govuk-grid-row" layout:fragment="page-content">
   <div class="govuk-grid-column-two-thirds">
+    <div th:if="${error_message_code}" class="alert alert-error">
+      <p th:text="#{${error_message_code}}">Error Message</p>
+    </div>
+
     <div th:if="${param.error}" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
-          There was an error when authenticating against the external identity provider. You may need to:
+          There was an error when authenticating against the single sign-on provider.
       </h2>
-      <div class="govuk-error-summary__body" th:if="${#strings.indexOf(param.error[0], 'The user account must be pre-created')}">
-        <ul class="govuk-list govuk-error-summary__list">
-          <li>Sign in with your email address and password</li>
-          <li>Switch region</li>
-          <li>Request an account</li>
+      <div th:if="${#strings.containsIgnoreCase(param.error[0], 'The user account must be pre-created')}">
+        <p class="govuk-body">
+          Your account has not had single sign-on enabled.
+          Please log in using your username and password
+          <a class="govuk-link" href="/login">here</a>. Alternatively, you may need to:
+        </p>
+        <ul class="govuk-list">
+          <li>
+            <a class="govuk-link" href="https://www.cloud.service.gov.uk/sign-in">Switch region</a>
+          </li>
+          <li>
+            <a class="govuk-link" href="https://www.cloud.service.gov.uk/signup">Request an account</a>
+          </li>
+          <li>
+            <a class="govuk-link" href="https://www.cloud.service.gov.uk/support">Contact Support</a>
+          </li>
         </ul>
       </div>
+      <p class="govuk-body"
+         th:unless="${#strings.containsIgnoreCase(param.error[0], 'The user account must be pre-created')}">
+        <a class="govuk-link"
+           href="https://www.cloud.service.gov.uk/support">
+        Contact GOV.UK PaaS support</a> if you have any issues with the platform.
+      </p>
     </div>
   </div>
 </div>

--- a/jobs/uaa-customized/templates/web/passcode.html
+++ b/jobs/uaa-customized/templates/web/passcode.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorator="layouts/main">
+<head>
+  <th:block layout:include="nav :: head"></th:block>
+</head>
+<div layout:fragment="page-nav">
+  <th:block layout:replace="nav :: nav"></th:block>
+</div>
+
+<div class="govuk-grid-row" layout:fragment="page-content">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Authentication code
+      </h1>
+      <div class="govuk-panel__body">
+        Your one-time passcode is <strong th:text="${passcode}">my-code</strong>
+      </div>
+    </div>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+        Copy and paste your code into the command line. Please ensure you keep this private.
+      </strong>
+    </div>
+  </div>
+</div>
+</html>


### PR DESCRIPTION
What
----

Adds and styles the following with GOV.UK Frontend CSS
- external_auth_error.html (presented when signing in using SSO without an account in UAA)
- error.html (generic error page)
- passcode.html (passcode page for command line SSO)

How to review
-------------

- Log in via SSO with an account that doesn't exist in UAA and review the error page
- Review the passcode page 
- Go to a page that doesn't exist in UAA and review the error page. For example, `https://login.example.digital/foo`

Who can review
--------------

Not me
