### PR TITLE
[#166028209] Scaffolding for Microsoft IDP in production

### DIFF
--- a/jobs/uaa-customized/templates/web/forgot_password.html
+++ b/jobs/uaa-customized/templates/web/forgot_password.html
@@ -12,7 +12,7 @@
                 <input type="hidden" name="client_id" th:value="${client_id}"/>
                 <input type="hidden" name="redirect_uri" th:value="${redirect_uri}"/>
                 <div class="govuk-form-group">
-                    <label class="govuk-label">Username</label>
+                    <label class="govuk-label">Email address</label>
                     <input name="username" type="text" autofocus="autofocus" class="govuk-input"/>
                 </div>
                 <input type="submit" value="Send reset password link" class="govuk-button"/>

--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -117,6 +117,10 @@
           Continue
         </a>
       </p>
+
+      <th:block th:each="oauthLink : ${oauthLinks}" th:inline="html">
+        <!-- [(${oauthLink.value})] [(${oauthLink.key})] -->
+      </th:block>
     </div>
   </div>
 </div>

--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -117,20 +117,6 @@
           Continue
         </a>
       </p>
-
-      <h2 class="govuk-heading-m">Microsoft</h2>
-
-      <p class="govuk-body">
-        This option is only available to internal users.
-      </p>
-
-      <p class="govuk-body" th:each="maybeMS : ${oauthLinks}">
-        <a class="govuk-button govuk-button--secondary"
-           th:href="${maybeMS.key}"
-           th:if="${#strings.containsIgnoreCase(maybeMS.value, 'microsoft')}">
-          Continue
-        </a>
-      </p>
     </div>
   </div>
 </div>

--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -102,14 +102,34 @@
         Use single sign-on
       </h1>
 
+      <h2 class="govuk-heading-m">Google</h2>
+
       <p class="govuk-body">
-      This option is only available to internal users.
+        This option is only available to users with a
+        <code>@digital.cabinet-office.gov.uk</code> email address, who have
+        enabled single sign-on using the admin panel.
       </p>
 
-      <p class="govuk-body" th:each="oauthLink : ${oauthLinks}">
+      <p class="govuk-body" th:each="maybeGoogle : ${oauthLinks}">
         <a class="govuk-button govuk-button--secondary"
-           th:href="${oauthLink.key}"
-           th:text="${'Sign in using ' + oauthLink.value}"></a>
+           th:href="${maybeGoogle.key}"
+           th:if="${#strings.containsIgnoreCase(maybeGoogle.value, 'google')}">
+          Continue
+        </a>
+      </p>
+
+      <h2 class="govuk-heading-m">Microsoft</h2>
+
+      <p class="govuk-body">
+        This option is only available to internal users.
+      </p>
+
+      <p class="govuk-body" th:each="maybeMS : ${oauthLinks}">
+        <a class="govuk-button govuk-button--secondary"
+           th:href="${maybeMS.key}"
+           th:if="${#strings.containsIgnoreCase(maybeMS.value, 'microsoft')}">
+          Continue
+        </a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
What
----

[This story](https://www.pivotaltracker.com/story/show/166028209) is to enable Microsoft as an IDP in production, but not enable it for users.

This PR will, eventually enable the sign in page to look like this:

![image](https://user-images.githubusercontent.com/1482692/58551732-a9b3e880-8208-11e9-957d-73c4e0641064.png)

However, there is a commit which deletes the Microsoft section. This is because @debsdee and I have gone through the user journey and worked out an acceptable solution (given the UAA circumstances). When it comes to enabling Microsoft for everyone, we can revert this commit and the journey will be good.

When deployed, without reverting the delete Microsoft commit, the sign in page looks like:

![image](https://user-images.githubusercontent.com/1482692/58552225-ce5c9000-8209-11e9-9bbd-c89aefe61c2b.png)

This PR also puts ALL of the oauth links as HTML comments in the source of the page, so we can test in production, and allow our users to test, without affecting the visible user journey.

![Screen Shot 2019-05-29 at 12 07 40](https://user-images.githubusercontent.com/1482692/58552477-66f31000-820a-11e9-8c67-b22504e4ef21.png)

Lastly, this PR fixes a typo, wherein on the "forgot password" page we asked for the "Username" of the user, which is inconsistent, and it should be "Email address":

![image](https://user-images.githubusercontent.com/1482692/58552392-327f5400-820a-11e9-90fc-64aa2bfc876e.png)

How to review
-------------

Deploy this to your development environment

Who can review
--------------

Not @tlwr
