### PR TITLE
[#166116777] Link region name to the multi-region sign-in page

### DIFF
--- a/jobs/uaa-customized/templates/web/layouts/main.html
+++ b/jobs/uaa-customized/templates/web/layouts/main.html
@@ -52,9 +52,9 @@
           <a href="https://www.cloud.service.gov.uk/" class="govuk-header__link govuk-header__link--service-name">
             Platform as a Service
           </a>
-          <strong class="govuk-tag govuk-phase-banner__content__tag region <%= p("region") %>">
+          <a href="https://www.cloud.service.gov.uk/sign-in" class="govuk-tag govuk-phase-banner__content__tag region <%= p("region") %>">
             <%= p("region") %>
-          </strong>
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
What
----

It is helpful that the login page says "IRELAND" or "LONDON" in the top-right. But users did not have a readily available way to change environment.

This commit makes the "IRELAND" or "LONDON" text a link leading to the page on our product page which gives users a choice of which environment to sign into [1].

[1] https://www.cloud.service.gov.uk/sign-in

How to review
-------------

Code review.

Who can review
--------------

Not @46bit