### PR TITLE
[#166697589] Improve sso enabled reset password error message

### DIFF
--- a/jobs/uaa-customized/spec
+++ b/jobs/uaa-customized/spec
@@ -38,6 +38,8 @@ templates:
   web/error.html: web/error.html
   web/passcode.html: web/passcode.html
 
+  mail/reset_password_unavailable.html: mail/reset_password_unavailable.html
+
 properties:
   region:
     description: "AWS Region Name"

--- a/jobs/uaa-customized/templates/mail/reset_password_unavailable.html
+++ b/jobs/uaa-customized/templates/mail/reset_password_unavailable.html
@@ -1,0 +1,24 @@
+
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head lang="en">
+    <meta charset="UTF-8" />
+</head>
+<body>
+<p>
+    A request has been made to reset your <th:block th:text="${serviceName}">ExampleService </th:block>
+    account password for <th:block th:text="${email}">user@example.com</th:block>.
+</p>
+<p>
+    However, your account is authenticated using a single sign-on provider such as Google, and
+    <th:block th:text="${serviceName}">ExampleService </th:block> does not manage your credentials.
+</p>
+<p>
+    To change your credentials, follow the password reset flow for your single sign-on provider.
+</p>
+<p>
+    Thank you,<br />
+    <th:block th:text="${serviceName}">The Administration</th:block>
+</p>
+</body>
+</html>

--- a/jobs/uaa-customized/templates/post-start
+++ b/jobs/uaa-customized/templates/post-start
@@ -65,8 +65,11 @@ pushd "${WAR_TEMPDIR}"
 
   mkdir -p templates/web/layouts
   mkdir -p templates/web/invitations
+  mkdir -p templates/mail
   cp -a "${JOB_DIR}"/web/* templates/web
+  cp -a "${JOB_DIR}"/mail/* templates/mail
   zip -r "${JARFILE}" templates/web
+  zip -r "${JARFILE}" templates/mail
   zip "$WARFILE" "$JARFILE"
 
   mkdir -p resources


### PR DESCRIPTION
What
---
Improves the error message sent to SSO users who request a password reset

How to review
---
1. Look at this sample error message

>A request has been made to reset your GOV.UK PaaS account password for user@example.com
>
>However, your account is authenticated using a single sign-on provider such as Google, and GOV.UK PaaS  does manage your credentials.
>
>To change your credentials, follow the password reset flow for your single sign-on provider.
>
>Thank you,
>GOV.UK PaaS 

2. Check I've added it to the spec file properly

Who can review
---
Not @AP-Hunt 