### PR TITLE
Redesign reset password page; add copy passcode button

### DIFF
--- a/jobs/uaa-customized/spec
+++ b/jobs/uaa-customized/spec
@@ -34,6 +34,7 @@ templates:
   web/login.html: web/login.html
   web/invitations/accept_invite.html: web/invitations/accept_invite.html
   web/forgot_password.html: web/forgot_password.html
+  web/reset_password.html: web/reset_password.html
   web/external_auth_error.html: web/external_auth_error.html
   web/error.html: web/error.html
   web/passcode.html: web/passcode.html

--- a/jobs/uaa-customized/templates/web/passcode.html
+++ b/jobs/uaa-customized/templates/web/passcode.html
@@ -16,7 +16,10 @@
         Authentication code
       </h1>
       <div class="govuk-panel__body">
-        Your one-time passcode is <strong th:text="${passcode}">my-code</strong>
+        <p>
+          Your one-time passcode is
+          <strong th:text="${passcode}">my-code</strong>
+        </p>
       </div>
     </div>
     <div class="govuk-warning-text">
@@ -27,5 +30,35 @@
       </strong>
     </div>
   </div>
+
+  <script type="text/javascript">
+  (function(){
+    if (navigator && navigator.clipboard && navigator.clipboard.writeText) {
+      var panelSelector = '.govuk-panel.govuk-panel--confirmation .govuk-panel__body';
+      var passcodeSelector = panelSelector + ' strong';
+      var buttonSelector = panelSelector + ' button';
+      var buttonContentsBefore = 'Copy passcode to clipboard';
+      var buttonContentsAfter = 'Copied to clipboard';
+
+      var newButtonElement = document.createElement('button');
+      newButtonElement.classList.add('govuk-button');
+      newButtonElement.classList.add('govuk-button--secondary');
+      newButtonElement.innerText = buttonContentsBefore;
+      newButtonElement.onclick = function() {
+        var passcodeElement = document.querySelector(passcodeSelector);
+        var buttonElement  = document.querySelector(buttonSelector);
+
+        var passcode = passcodeElement.innerText.trim();
+        navigator.clipboard.writeText(passcode).then(function() {
+          buttonElement.innerText = buttonContentsAfter;
+        });
+      };
+
+      document.querySelector(panelSelector).appendChild(newButtonElement);
+      newButtonElement.focus();
+    }
+  })();
+  </script>
 </div>
+
 </html>

--- a/jobs/uaa-customized/templates/web/reset_password.html
+++ b/jobs/uaa-customized/templates/web/reset_password.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorator="layouts/main">
+<div class="island" layout:fragment="page-content">
+    <h1>Reset Password</h1>
+    <div class="island-content">
+        <div th:text="|Username: ${username}|" class="email-display">Username: user@example.com</div>
+        <form th:action="@{/reset_password.do}" method="post" novalidate="novalidate">
+            <input type="hidden" name="code" th:value="${code}"/>
+            <input type="hidden" name="email" th:value="${email}"/>
+            <input type="hidden" name="username" th:value="${username}"/>
+            <div th:if="${message_code}" th:text="#{'reset_password.' + ${message_code}}" class="error-message"></div>
+            <div th:if="${message}" th:text="${message}" class="error-message"></div>
+            <input name="password" type="password" placeholder="New Password" autocomplete="off" class="form-control"/>
+            <input name="password_confirmation" type="password" placeholder="Confirm" autocomplete="off" class="form-control"/>
+            <input type="submit" value="Create new password" class="island-button"/>
+        </form>
+    </div>
+</div>
+</html>

--- a/jobs/uaa-customized/templates/web/reset_password.html
+++ b/jobs/uaa-customized/templates/web/reset_password.html
@@ -2,20 +2,68 @@
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorator="layouts/main">
-<div class="island" layout:fragment="page-content">
-    <h1>Reset Password</h1>
-    <div class="island-content">
-        <div th:text="|Username: ${username}|" class="email-display">Username: user@example.com</div>
+<div layout:fragment="page-content">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-l">Reset Password</h1>
+        </div>
+        <div class="govuk-grid-column-two-thirds">
         <form th:action="@{/reset_password.do}" method="post" novalidate="novalidate">
             <input type="hidden" name="code" th:value="${code}"/>
             <input type="hidden" name="email" th:value="${email}"/>
-            <input type="hidden" name="username" th:value="${username}"/>
-            <div th:if="${message_code}" th:text="#{'reset_password.' + ${message_code}}" class="error-message"></div>
-            <div th:if="${message}" th:text="${message}" class="error-message"></div>
-            <input name="password" type="password" placeholder="New Password" autocomplete="off" class="form-control"/>
-            <input name="password_confirmation" type="password" placeholder="Confirm" autocomplete="off" class="form-control"/>
-            <input type="submit" value="Create new password" class="island-button"/>
+
+            <div class="govuk-error-summary"
+                 th:if="${message_code} or ${message}"
+                 aria-labelledby="errors"
+                 role="alert"
+                 tabindex="-1">
+                <h2 class="govuk-error-summary__title" id="errors">
+                    There is a problem
+                </h2>
+                <div class="govuk-error-summary__body">
+                    <ul class="govuk-list govuk-error-summary__list">
+                        <li th:text="#{'reset_password.' + ${message_code}}"></li>
+                        <li th:text="${message}"></li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="username">
+                    Email address
+                </label>
+                <input id="username"
+                       name="username"
+                       class="govuk-input"
+                       th:value="${username}" readonly/>
+            </div>
+
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="password">
+                    New password
+                </label>
+                <input name="password"
+                       id="password"
+                       type="password"
+                       class="govuk-input"
+                       autocomplete="off"/>
+            </div>
+
+            <div class="govuk-form-group">
+                <label class="govuk-label" for="password_confirmation">
+                    New password confirmation
+                </label>
+                <input name="password_confirmation"
+                       id="password_confirmation"
+                       type="password"
+                       class="govuk-input"
+                       autocomplete="off"/>
+            </div>
+
+            <input type="submit"
+                   value="Reset password" class="govuk-button"/>
         </form>
+        </div>
     </div>
 </div>
 </html>


### PR DESCRIPTION
What
---

### Password reset

The reset password page did not have styling, which mean users saw gross looking pages

![Screen Shot 2019-07-22 at 10 34 16](https://user-images.githubusercontent.com/1482692/61622125-188f4a00-ac6c-11e9-937f-65e3baf2c76d.png)
___A screenshot showing the updated password reset page___

### Copy to clipboard button

Adds a javascript required button for copying the passcode to the clipboard.

This button only appears if:

- Javascript is enabled
- The user has the required `navigator.clipboard.writeText` method

If the button should appear then it is focused.

![Screen Shot 2019-07-22 at 10 35 59](https://user-images.githubusercontent.com/1482692/61622222-4a081580-ac6c-11e9-9c0e-df02565ba2f1.png)
___A screenshot showing the copy to clipboard button (code is fake)___

How to review
---

Code review

Reset a password in your development environment

Use SSO to get a passcode in your development environment