### PR TITLE
[#166927205] Remove cabinet office google restriction text

### DIFF
--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -105,8 +105,7 @@
       <h2 class="govuk-heading-m">Google</h2>
 
       <p class="govuk-body">
-        This option is only available to users with a
-        <code>@digital.cabinet-office.gov.uk</code> email address who have
+        This option is open to everyone with a Google account who has
         enabled single sign-on using the admin panel.
       </p>
 


### PR DESCRIPTION
What
----

Remove mention of @digital.cabinet-office.gov.uk addresses on login screen. We're opening up Google SSO to all tenants, so this restriction is no longer true.

How to review
-------------
Code review. This change is simple enough that it probably doesn't need a test deployment. 


Who can review
--------------
Anyone
