### PR TITLE
[#167666727] Improve SSO error sign in instruction text

### DIFF
--- a/jobs/uaa-customized/templates/web/external_auth_error.html
+++ b/jobs/uaa-customized/templates/web/external_auth_error.html
@@ -16,8 +16,7 @@
       <div th:if="${#strings.containsIgnoreCase(param.error[0], 'The user account must be pre-created')}">
         <p class="govuk-body">
           Your account has not had single sign-on enabled.
-          Please log in using your username and password
-          <a class="govuk-link" href="/login">here</a>. Alternatively, you may need to:
+          Please <a class="govuk-link" href="/login">sign in using your username and password</a>. Alternatively, you may need to:
         </p>
         <ul class="govuk-list">
           <li>


### PR DESCRIPTION
What
----

Quote Luke Malcher
> The language we use elsewhere (for example on the sign in page) is "sign in"
not "log in".
> 
> Accessibility standards usually say that link text should be explanatory. Using
"here" as link text is an antipattern because it provides no context for people
using screen readers.

How to review
-------------
1. Code review
1. This is such a superficial change that I doubt it needs to run down a pipeline, but feel free to run it down your pipeline
1. Once you're happy with it and it's merged, raise the PR to bump the version in `paas-cf`

Who can review
--------------
Anyone