### PR TITLE
Turn off autocomplete on login form fields

### DIFF
--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -52,7 +52,7 @@
           </label>
           <input th:name="${prompt.key}"
                  th:type="${prompt.value[0]}"
-                 th:attr="autocomplete=${(prompt.value[0] == 'password') ? 'off' : null}"
+                 th:attr="autocomplete='off'"
                  class="govuk-input"/>
         </div>
 


### PR DESCRIPTION
What
----

IT Health Check report identified enabled autocomplete on sensitive form fields as a security risk.

We had discussed this with Head of Accessibility and the suggestion is to set autocomplete to 'off' for security reasons.

Source: https://knowbility.org/blog/2018/WCAG21-135InputPurpose/

