### PR TITLE
Fix error summary link href syntax and tweak login page layout (again)

### DIFF
--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -40,7 +40,7 @@
         </strong>
       </div>
     </div>
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-6">
       <h2 class="govuk-heading-m">
         Use email address
       </h2>
@@ -101,7 +101,7 @@
       </p>
     </div>
 
-    <div class="govuk-grid-column-one-half" th:unless="${oauthLinks.isEmpty()}">
+    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-6" th:unless="${oauthLinks.isEmpty()}">
 
       <h2 class="govuk-heading-m">
         Use Google single sign-on
@@ -122,29 +122,20 @@
       </p>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <details class="govuk-details" data-module="govuk-details">
-        <summary class="govuk-details__summary">
-          <span class="govuk-details__summary-text">
-            GOV.UK Platform as a Service - Platform Administrators
-          </span>
-        </summary>
-
-        <div class="govuk-details__text">
-          <p class="govuk-body">
-            This option is only applicable to the platform administrators of
-            GOV.UK Platform as a Service. If you are hosting your service on
-            GOV.UK PaaS, you should use one of the options above.
-          </p>
+      <h2 class="govuk-heading-m">GOV.UK Platform as a Service - Platform Administrators</h2>
+      <p class="govuk-body">
+        This option is only applicable to the platform administrators of
+        GOV.UK Platform as a Service. If you are hosting your service on
+        GOV.UK PaaS, you should use one of the options above.
+      </p>
           
-          <p class="govuk-body" th:each="maybeAdminGoogle : ${oauthLinks}">
-            <a class="govuk-link"
-              th:href="${maybeAdminGoogle.key}"
-              th:if="${#strings.equals(maybeAdminGoogle.value, 'AdminGoogle')}">
-              I am an operator
-            </a>
-          </p>
-        </div>
-      </details>
+      <p class="govuk-body" th:each="maybeAdminGoogle : ${oauthLinks}">
+        <a class="govuk-link"
+          th:href="${maybeAdminGoogle.key}"
+          th:if="${#strings.equals(maybeAdminGoogle.value, 'AdminGoogle')}">
+          I am an operator
+        </a>
+      </p>
     </div>
   </div>
 </div>

--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -11,7 +11,7 @@
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
             <li>
-              <a th:href="#username" th:text="#{'login.' + ${param.error[0]}}">Error Message</a>
+              <a href="#username" th:href="@{#username}" th:text="#{'login.' + ${param.error[0]}}">Error Message</a>
             </li>
           </ul>
         </div>
@@ -24,7 +24,7 @@
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
             <li>
-              <a th:href="#username" th:text="#{'login.' + ${error}}">Error Message</a>
+              <a href="#username" th:href="@{#username}" th:text="#{'login.' + ${error}}">Error Message</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
What
----

- Fix error summary link href syntax
- Provide a heading for Platform Admin login and extract content from the disclosure element

How to review
-------------

- deploy to dev env
- enter wrong email or password
- check to see if you get an error message 

Who can review
--------------

not @kr8n3r 

Visual changes
---------------
**Before**
<img width="1012" alt="Screenshot 2020-08-06 at 09 11 16" src="https://user-images.githubusercontent.com/3758555/89507721-cd879c80-d7c4-11ea-8162-2f8387651a52.png">


**After**
<img width="1010" alt="Screenshot 2020-08-06 at 09 03 14" src="https://user-images.githubusercontent.com/3758555/89507685-c2347100-d7c4-11ea-9fa4-dc20a1f6e2b2.png">
