### PR TITLE
Fix dac discovered issues

### DIFF
--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -72,7 +72,9 @@
                  th:name="${prompt.key}"
                  th:type="${prompt.value[1] == 'Email' ? 'email' : prompt.value[0]}"
                  th:attr="autocomplete='off'"
-                 class="govuk-input"/>
+                 th:aria-describedby="${param.error}? ${prompt.key + '-error'}"
+                 class="govuk-input"
+                 th:classappend="${param.error}? 'govuk-input--error'"/>
         </div>
 
         <input th:if="${session.SPRING_SECURITY_SAVED_REQUEST}"

--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -11,19 +11,6 @@
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
             <li>
-              <a href="#username" th:href="@{#username}" th:text="#{'login.' + ${param.error[0]}}">Error Message</a>
-            </li>
-          </ul>
-        </div>
-      </div>
-
-      <div th:if="${error}" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <li>
               <a href="#username" th:href="@{#username}">Unable to verify email address</a>
             </li>
             <li>
@@ -53,14 +40,14 @@
             accept-charset="UTF-8">
 
         <div th:class="govuk-form-group"
-             th:classappend="${error}? 'govuk-form-group--error'"
+             th:classappend="${param.error}? 'govuk-form-group--error'"
              th:each="prompt,iter : ${prompts}">
           <label class="govuk-label"
                  th:attr="for=${prompt.key}"
                  th:text="${prompt.value[1] == 'Email' ? 'Email address' : prompt.value[1]}">
           </label>
           <span
-              th:if="${error}"
+              th:if="${param.error}"
               th:id="${prompt.key + '-error'}"
               class="govuk-error-message">
             <span class="govuk-visually-hidden">Error:</span>

--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -70,7 +70,7 @@
           </span>
           <input th:id="${prompt.key}"
                  th:name="${prompt.key}"
-                 th:type="${prompt.value[0]}"
+                 th:type="${prompt.value[1] == 'Email' ? 'email' : prompt.value[0]}"
                  th:attr="autocomplete='off'"
                  class="govuk-input"/>
         </div>

--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -24,7 +24,10 @@
         <div class="govuk-error-summary__body">
           <ul class="govuk-list govuk-error-summary__list">
             <li>
-              <a href="#username" th:href="@{#username}" th:text="#{'login.' + ${error}}">Error Message</a>
+              <a href="#username" th:href="@{#username}">Unable to verify email address</a>
+            </li>
+            <li>
+              <a href="#password" th:href="@{#password}">Unable to match password with an email address</a>
             </li>
           </ul>
         </div>
@@ -49,12 +52,22 @@
             novalidate="novalidate"
             accept-charset="UTF-8">
 
-        <div class="govuk-form-group"
+        <div th:class="govuk-form-group"
+             th:classappend="${error}? 'govuk-form-group--error'"
              th:each="prompt,iter : ${prompts}">
           <label class="govuk-label"
                  th:attr="for=${prompt.key}"
                  th:text="${prompt.value[1] == 'Email' ? 'Email address' : prompt.value[1]}">
           </label>
+          <span
+              th:if="${error}"
+              th:id="${prompt.key + '-error'}"
+              class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span>
+            <span
+                th:text="${prompt.value[1] == 'Email' ? 'Unable to verify email address' : 'Unable to match password with an email address'}">
+            </span>
+          </span>
           <input th:id="${prompt.key}"
                  th:name="${prompt.key}"
                  th:type="${prompt.value[0]}"


### PR DESCRIPTION
What
----

Our testers have noticed, that the fields are not intuitive enough when
it comes to displaying there is an error on the login form.

This change will display two separate errors above the header, and two
errors right next to the text fields to help out users.

When viewing the login form on a mobile device, there are variations of
keyboards that are presented to the user depending what input type has
been set on the field.

Our testers have found it less usable to enter an email address, due to
need of switching between alpha to numeric characters. Lack of an @ is
also not ideal.

We've had two choices, either, set the `inputmode="email"` or
`type="email"`. The difference between the two, is additional validation
done by the browser of the `type` attribute. Since we have disabled the
validation on the form entirely, and we don't care for the browser
validation, `type` attribute is less "effort" to implement.

How to review
-------------

- Deploy to your dev env
- See the login page (I did not get a chance to test it myself ⚠️⚠️⚠️ )