### PR TITLE
Add link to the accessibility statement

### DIFF
--- a/jobs/uaa-customized/templates/web/layouts/main.html
+++ b/jobs/uaa-customized/templates/web/layouts/main.html
@@ -93,16 +93,49 @@
             <h2 class="govuk-visually-hidden">Support links</h2>
             <ul class="govuk-footer__inline-list">
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="https://www.gov.uk/government/organisations/government-digital-service">
-                  Built by the Government Digital Service
+                <a
+                  class="govuk-footer__link"
+                  href="https://www.cloud.service.gov.uk/privacy-notice"
+                >
+                  Privacy notice
                 </a>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="https://www.cloud.service.gov.uk/cookies">
+                <a
+                  class="govuk-footer__link"
+                  href="https://www.cloud.service.gov.uk/terms-of-use"
+                >
+                  Terms of use
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a
+                  class="govuk-footer__link"
+                  href="https://www.cloud.service.gov.uk/accessibility-statement"
+                >
+                  Accessibility statement
+                </a>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <a
+                  class="govuk-footer__link"
+                  href="https://www.cloud.service.gov.uk/cookies"
+                >
                   Cookies
                 </a>
               </li>
+              <li class="govuk-footer__inline-list-item">
+                <a
+                  class="govuk-footer__link"
+                  href="https://status.cloud.service.gov.uk"
+                >
+                  System status
+                </a>
+              </li>
             </ul>
+            <div class="govuk-footer__meta-custom">
+              Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">Government Digital Service</a>
+            </div>
             <svg
               role="presentation"
               focusable="false"


### PR DESCRIPTION
**Needs https://github.com/alphagov/paas-product-pages/pull/82**

## Changes Proposed

Add link to accessibility statement and update footer to [match paas-admin](https://github.com/alphagov/paas-admin/pull/1074)

## Visual change

### Before
<img width="1029" alt="Screenshot 2020-09-21 at 10 37 26" src="https://user-images.githubusercontent.com/3758555/93752423-8e879c00-fbf6-11ea-8c0f-6d1eced3e563.png">


### After
<img width="1001" alt="Screenshot 2020-09-21 at 10 27 15" src="https://user-images.githubusercontent.com/3758555/93752439-95aeaa00-fbf6-11ea-9f06-28a48f77a43d.png">

