### PR TITLE
Enable links to 'forgotten password' and 'create an account' functionality from login page

### DIFF
--- a/jobs/uaa-customized/templates/web/login.html
+++ b/jobs/uaa-customized/templates/web/login.html
@@ -90,16 +90,16 @@
         <button class="govuk-button" data-module="govuk-button">Continue <span class="govuk-visually-hidden"> with email and password sign in</span></button>
       </form>
 
-      <p class="govuk-body" th:unless="${#strings.isEmpty(links['forgotPasswordLink'])}">
+      <p class="govuk-body">
         <a href="/forgot_password"
-           th:href="@{${links['forgotPasswordLink']}}"
+           th:href="${'https://' + #strings.replace(#vars.getVariable('entityID'),'login','admin') + '/password/request-reset'}"
            class="govuk-link">Forgot your password?</a>
       </p>
 
-      <p class="govuk-body" th:unless="${#strings.isEmpty(links['createAccountLink'])}">
+      <p class="govuk-body">
         <a href="/create_account"
-         th:href="@{${links['createAccountLink']}}"
-         class="govuk-link">Request an account</a>
+           th:href="${'https://' + #strings.replace(#vars.getVariable('entityID'),'login','admin') + '/support/sign-up'}"
+           class="govuk-link">Request an account</a>
       </p>
     </div>
 


### PR DESCRIPTION
What
----
[Story](https://www.pivotaltracker.com/story/show/174949344)

Add links to 'forgot password' and 'create an account' from the login page.

How to review
-------------
1. Code review
2. Build the new release (if needed) - the CI job is [here](https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/uaa-customized-release)
3. Update the [paas-cf PR](https://github.com/alphagov/paas-cf/pull/2524) with the correct version information, if needed. 
3. Deploy paas-cf to Dev and then higher environments. (detailed instructions in [paas-cf PR](https://github.com/alphagov/paas-cf/pull/2524).

Who can review
--------------
not @barsutka 
