### PR TITLE
Update footer layout and items to match paas-admin

### DIFF
--- a/jobs/uaa-customized/templates/web/layouts/main.html
+++ b/jobs/uaa-customized/templates/web/layouts/main.html
@@ -87,86 +87,64 @@
     </div>
 
     <footer class="govuk-footer " role="contentinfo">
-      <div class="govuk-width-container ">
-        <div class="govuk-footer__meta">
-          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-            <h2 class="govuk-visually-hidden">Support links</h2>
-            <ul class="govuk-footer__inline-list">
-              <li class="govuk-footer__inline-list-item">
-                <a
-                  class="govuk-footer__link"
-                  href="https://www.cloud.service.gov.uk/privacy-notice"
-                >
-                  Privacy notice
-                </a>
+			<div class="govuk-width-container ">
+				<div class="govuk-footer__navigation">
+					<div class="govuk-footer__section">
+						<h2 class="govuk-footer__heading govuk-heading-m">Support</h2>
+						<ul class="govuk-footer__list">
+							<li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://status.cloud.service.gov.uk">System status</a>
+							</li>
+							<li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://docs.cloud.service.gov.uk/">Documentation</a>
+							</li>
+							<li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://admin.london.cloud.service.gov.uk/support">Contact support</a>
               </li>
-              <li class="govuk-footer__inline-list-item">
-                <a
-                  class="govuk-footer__link"
-                  href="https://www.cloud.service.gov.uk/terms-of-use"
-                >
-                  Terms of use
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a
-                  class="govuk-footer__link"
-                  href="https://www.cloud.service.gov.uk/accessibility-statement"
-                >
-                  Accessibility statement
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a
-                  class="govuk-footer__link"
-                  href="https://www.cloud.service.gov.uk/cookies"
-                >
-                  Cookies
-                </a>
-              </li>
-              <li class="govuk-footer__inline-list-item">
-                <a
-                  class="govuk-footer__link"
-                  href="https://status.cloud.service.gov.uk"
-                >
-                  System status
-                </a>
-              </li>
-            </ul>
-            <div class="govuk-footer__meta-custom">
-              Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">Government Digital Service</a>
-            </div>
-            <svg
-              role="presentation"
-              focusable="false"
-              class="govuk-footer__licence-logo"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 483.2 195.7"
-              height="17"
-              width="41"
-              >
-              <path
-                fill="currentColor"
-                d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-                /> </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a
-                class="govuk-footer__link"
-                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                rel="license"
-                >Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
-          </div>
-          <div class="govuk-footer__meta-item">
-            <a
-              class="govuk-footer__link govuk-footer__copyright-logo"
-              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-              >© Crown copyright</a>
-          </div>
-        </div>
-      </div>
-    </footer>
+              <li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://github.com/alphagov/paas-roadmap/projects/1?fullscreen=true">Roadmap</a>
+							</li>
+						</ul>
+					</div>
+					<div class="govuk-footer__section">
+						<h2 class="govuk-footer__heading govuk-heading-m">Legal terms</h2>
+						<ul class="govuk-footer__list">
+							<li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://www.cloud.service.gov.uk/privacy-notice">Privacy notice</a>
+							</li>
+							<li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://www.cloud.service.gov.uk/terms-of-use">Terms of use</a>
+							</li>
+							<li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://www.cloud.service.gov.uk/accessibility-statement">Accessibility statement</a>
+							</li>
+							<li class="govuk-footer__list-item">
+								<a class="govuk-footer__link" href="https://www.cloud.service.gov.uk/cookies">Cookies</a>
+							</li>
+						</ul>
+					</div>
+				</div>
+				<hr class="govuk-footer__section-break">
+					<div class="govuk-footer__meta">
+						<div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+							<div class="govuk-footer__meta-custom">Built by the 
+								<a href="https://www.gov.uk/government/organisations/government-digital-service" class="govuk-footer__link">Government Digital Service</a>
+							</div>
+							<svg role="presentation" focusable="false" class="govuk-footer__licence-logo"
+								xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+								<path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
+							</svg>
+							<span class="govuk-footer__licence-description">All content is available under the 
+								<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+							</span>
+						</div>
+						<div class="govuk-footer__meta-item">
+							<a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+						</div>
+					</div>
+				</div>
+      </footer>
+      
     <script src="/resources/oss/javascripts/govuk-frontend-3.7.0.min.js" th:href="@{${assetBaseUrl}+'/javascripts/govuk-frontend-3.7.0.min.js'}"></script>
     <script>
       window.GOVUKFrontend.initAll()


### PR DESCRIPTION
What
----

Update footer layout and move items to echo changes in [paas-admin](https://admin.london.cloud.service.gov.uk/support)
<img width="1100" alt="Screenshot 2020-11-24 at 15 03 12" src="https://user-images.githubusercontent.com/3758555/100111660-34a98980-2e66-11eb-8131-b9a95fdc3804.png">


How to review
-------------

- deploy to test
- [changes without whitespace](https://github.com/alphagov/paas-uaa-customized-boshrelease/pull/25/files?diff=split&w=1)

Who can review
--------------

not @kr8n3r 
