### PR TITLE
Link to our channel on cross-gov Slack instance

### DIFF
--- a/jobs/uaa-customized/templates/web/layouts/main.html
+++ b/jobs/uaa-customized/templates/web/layouts/main.html
@@ -103,7 +103,10 @@
               </li>
               <li class="govuk-footer__list-item">
 								<a class="govuk-footer__link" href="https://github.com/alphagov/paas-roadmap/projects/1?fullscreen=true">Roadmap</a>
-							</li>
+              </li>
+              <li class="govuk-footer__list-item">
+                <a class="govuk-footer__link" href="https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-paas">Chat to us on Slack</a>
+              </li>
 						</ul>
 					</div>
 					<div class="govuk-footer__section">


### PR DESCRIPTION
What
----

Link to our channel on cross-gov Slack instance to be consistent with Pay and Notify.

How to review
-------------

- deploy to your dev env
- click on the footer link. if signed into slack it should open the govuk-paas channel

Who can review
--------------

not @kr8n3r 
