### PR TITLE
Add security.txt to login domain

### DIFF
--- a/jobs/uaa-customized/spec
+++ b/jobs/uaa-customized/spec
@@ -31,6 +31,7 @@ templates:
   web/external_auth_error.html: web/external_auth_error.html
   web/error.html: web/error.html
   web/passcode.html: web/passcode.html
+  web/.well-known/security.txt: web/.well-known/security.txt
 
   mail/reset_password_unavailable.html: mail/reset_password_unavailable.html
 

--- a/jobs/uaa-customized/templates/web/.well-known/security.txt
+++ b/jobs/uaa-customized/templates/web/.well-known/security.txt
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; https://vdp.cabinetoffice.gov.uk/.well-known/security.txt" />
+  </head>
+  <body>
+    <p><a href="https://vdp.cabinetoffice.gov.uk/.well-known/security.txt">https://vdp.cabinetoffice.gov.uk/.well-known/security.txt</a></p>
+  </body>
+</html>


### PR DESCRIPTION
What
----

- Added a `security.txt` file which is HTML containing a redirect (in meta header) and a link to the central VDP security.txt (I suspect it's not this simple and it'll get interpreted as a text file and not a HTML file)
- Added a line linking to the file in the `spec` file 

How to review
-------------

Not sure, I'm hoping there's a test login environment that could be tested?

Who can review
--------------

Solo: @OllieJC, @LeePorte pointed me here.
Anyone who can set up/deploy to a test login environment